### PR TITLE
handling unknown epss scores edge case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm-epss-audit",
-  "version": "0.0.10",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-epss-audit",
-      "version": "0.0.10",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-epss-audit",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Use EPSS scores to prioritize NPM Audit findings",
   "main": "bin/index.js",
   "bin": {


### PR DESCRIPTION
I tested this against a repo that had https://www.cve.org/CVERecord?id=CVE-2023-26364, which is in the 'reserved' state and currently has no details associated with it, but still shows up in an audit as it is tracked by https://github.com/advisories/GHSA-hpx4-r86g-5jrg.

This change will make the script print an EPSS Score of 'N/A' when it can't find a score for the CVE. It will also add the advisory link to the output table so that it's easy for the user to find the source of the finding when CVEs are in this state and getting clear info from the CVE database isn't possible.
